### PR TITLE
Add kubernetes-controllers

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-deployment
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: homework-pod
+  template:
+    metadata:
+      labels:
+        app: homework-pod
+    spec:
+      nodeSelector:
+         homework: "true"
+      initContainers:
+        - name: init
+          image: busybox:1.37
+          command: ['sh', '-c', 'echo "Hello from init container." > /init/index.html']
+          volumeMounts:
+            - name: workdir
+              mountPath: /init
+      containers:
+        - name: web-server
+          image: python:3.9-slim
+          ports:
+            - containerPort: 8000
+          command: ['sh', '-c', 'python -m http.server 8000 --directory /homework']
+          volumeMounts:
+            - name: workdir
+              mountPath: /homework
+          lifecycle:
+            preStop:
+              exec:
+                command: ['rm', '-rf', '/homework/index.html']
+          readinessProbe:
+            exec:
+              command: ['cat', '/homework/index.html']
+            initialDelaySeconds: 3
+            periodSeconds: 60
+      volumes:
+        - name: workdir
+          emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework


### PR DESCRIPTION
# Выполнено ДЗ № 2 kubernetes-controllers

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - создан манифест namespace.yaml
 - создан манифест deployment.yaml

## Как запустить проект:
 - kubectl apply -f .\namespace.yaml
 - kubectl apply -f .\deployment.yaml
 - смотрим, почему поды в pending 
 kubectl describe pod homework-deployment-5d7dd769c8-q5bx9 -n homework
 - потому что надо лейбл на ноду повешать. Делаем:
kubectl get nodes 
kubectl label node minikube homework=true
 - проверяем, что поды поднялись
kubectl get po -n homework

## Как проверить работоспособность:
 - так как curl в образе пода нет, делаем так:
kubectl config set-context --current --namespace=homework
kubectl expose Deployment homework-deployment --type=NodePort --port=8000
kubectl port-forward service/homework-deployment 8000:8000
 - запрашиваем в 3 терминалах логи подов
kubectl logs -f homework-deployment-...
 - запрашиваем с хоста curl http://127.0.0.1:8000/
 - видим, что запрос идет все время в один под, убиваем его. Ожидаем, что запросы пойдут в другой под, пока первый переподнимается. Но почему то отваливается форвардинг. Только после повторного поднятия форварда начинаем видеть запросы во втором поде.
 

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
