### PR TITLE
Add hm kubernetes-monitoring

### DIFF
--- a/kubernetes-monitoring/0_nginx-ns.yaml
+++ b/kubernetes-monitoring/0_nginx-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-mon

--- a/kubernetes-monitoring/1_nginx-cm.yaml
+++ b/kubernetes-monitoring/1_nginx-cm.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+  namespace: nginx-mon
+data:
+  default.conf: |
+    server {
+        listen 80;
+        server_name _;
+
+        location / {
+            root /usr/share/nginx/html;
+            index index.html index.htm;
+        }
+
+        location /health {
+            access_log off;
+            return 200 "healthy\n";
+            add_header Content-Type text/plain;
+        }
+
+        location /status {
+            stub_status on;
+            access_log off;
+            allow all;
+        }
+    }

--- a/kubernetes-monitoring/3_nginx-deployment.yaml
+++ b/kubernetes-monitoring/3_nginx-deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: nginx-mon
+  labels:
+    app: nginx
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.24-alpine
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: default.conf
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 80
+          initialDelaySeconds: 30
+          periodSeconds: 10
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-config

--- a/kubernetes-monitoring/4_nginx-svc.yaml
+++ b/kubernetes-monitoring/4_nginx-svc.yaml
@@ -1,0 +1,16 @@
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: nginx-mon
+  labels:
+    app: nginx
+spec:
+  selector:
+    app: nginx
+  ports:
+  - port: 80
+    targetPort: 80
+  type: ClusterIP

--- a/kubernetes-monitoring/5_nginx-exporter-deployment.yaml
+++ b/kubernetes-monitoring/5_nginx-exporter-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-exporter
+  namespace: nginx-mon
+  labels:
+    app: nginx-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-exporter
+  template:
+    metadata:
+      labels:
+        app: nginx-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9113"
+    spec:
+      containers:
+      - name: nginx-exporter
+        image: nginx/nginx-prometheus-exporter:0.11.0
+        args:
+          - "-nginx.scrape-uri=http://nginx-service:80/status"
+        ports:
+        - containerPort: 9113
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "10m"
+          limits:
+            memory: "64Mi"
+            cpu: "50m"

--- a/kubernetes-monitoring/6_nginx-exporter-svc.yaml
+++ b/kubernetes-monitoring/6_nginx-exporter-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-exporter-service
+  namespace: nginx-mon
+  labels:
+    app: nginx-exporter
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9113"
+spec:
+  selector:
+    app: nginx-exporter
+  ports:
+  - port: 9113
+    targetPort: 9113
+  type: ClusterIP

--- a/kubernetes-monitoring/7_servicemonitor.yaml
+++ b/kubernetes-monitoring/7_servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-exporter
+  namespace: nginx-mon
+  labels:
+    app: nginx-exporter
+spec:
+  selector:
+    matchLabels:
+      app: nginx-exporter
+  endpoints:
+  - port: metrics
+    interval: 30s
+    path: /metrics
+    scrapeTimeout: 5s
+    honorLabels: true


### PR DESCRIPTION
# Выполнено ДЗ №

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Установка crd
helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
helm repo update
helm upgrade --install prometheus prometheus-community/kube-prometheus-stack \
  --namespace monitoring \
  --create-namespace \
  --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false

## Как запустить проект:
kubectl apply -f .
ps: в предыдущем задании уже делала с пересборкой образа для кастомного оператора. 
В данном мне кажется можно обойтись без этого.

## Как проверить работоспособность:
kubectl port-forward -n nginx-mon service/nginx-exporter-service 9113:9113 & sleep 2 && curl http://localhost:9113/metrics

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания